### PR TITLE
282 change style logic for match card

### DIFF
--- a/app/components/DashboardTile.js
+++ b/app/components/DashboardTile.js
@@ -33,20 +33,31 @@ const DashboardTile = ({
   // Calculate opacity map before rendering
   const player1Opacity = isOpaque(player1FinalScores, player2FinalScores)
 
+  // Get match winner from Opacity Array
+  const player1Wins = player1Opacity.filter(Boolean).length
+  const player2Wins = player1Opacity.length - player1Wins // Total length - player1Wins
+  const player1IsWinner = player1Wins > player2Wins
+  const player2IsWinner = player2Wins > player1Wins
+
   useEffect(() => {
     setClientLogo(logos[clientTeam])
     setOpponentLogo(logos[opponentTeam])
   }, [clientTeam, opponentTeam, logos])
-
   // Render function for scores
   const renderScore = (score, index, isPlayer1, tieScores) => {
-    const opacity = isPlayer1
-      ? player1Opacity[index]
-        ? '100%'
-        : '40%'
-      : !player1Opacity[index]
-        ? '100%'
-        : '40%'
+    const lastSetIndex =
+      player1FinalScores[2].score == null ? 1 : player1FinalScores.length - 1
+    const isLastSet = index === lastSetIndex
+    const opacity =
+      isUnfinished && isLastSet
+        ? '40%' // Grey out last set if unfinished
+        : isPlayer1
+          ? player1Opacity[index]
+            ? '100%'
+            : '40%'
+          : !player1Opacity[index]
+            ? '100%'
+            : '40%'
 
     return (
       !isNaN(score.score) && (
@@ -76,6 +87,20 @@ const DashboardTile = ({
     )
   }
 
+  // Render name opacity
+  const renderNameOpacity = (playerName, didWin) => {
+    return (
+      <div
+        style={{
+          position: 'relative',
+          opacity: isUnfinished ? '40%' : didWin ? '100%' : '40%'
+        }}
+      >
+        {playerName}
+      </div>
+    )
+  }
+
   return loading ? (
     <p>Loading ...</p>
   ) : (
@@ -92,7 +117,8 @@ const DashboardTile = ({
             <img src={clientLogo} alt={`${clientTeam} logo`} />
           </div>
           <div className={styles.playerInfoName}>
-            {player1Name} {isUnfinished && '(UF)'}
+            {renderNameOpacity(player1Name, player1IsWinner)}{' '}
+            {isUnfinished && '(UF)'}
           </div>
           <div className={styles.playerInfoScore}>
             {player1FinalScores.map((score, index) =>
@@ -106,7 +132,9 @@ const DashboardTile = ({
           <div className={styles.playerSchoolImgcontainer}>
             <img src={opponentLogo} alt={`${opponentTeam} logo`} />
           </div>
-          <div className={styles.playerInfoName}>{player2Name}</div>
+          <div className={styles.playerInfoName}>
+            {renderNameOpacity(player2Name, player2IsWinner)}
+          </div>
           <div className={styles.playerInfoScore}>
             {player2FinalScores.map((score, index) =>
               renderScore(score, index, false, player2TieScores)


### PR DESCRIPTION
Closes #282 

Updated styling logic for text opacity. Match loser names are now greyed out, and the both player names and last set are greyed out in unfinished matches. 