### PR TITLE
Resize Match Tiles for Mobile

### DIFF
--- a/app/components/DashboardTile.js
+++ b/app/components/DashboardTile.js
@@ -19,6 +19,7 @@ const DashboardTile = ({
   const { logos, loading } = useData()
   const [clientLogo, setClientLogo] = useState(null)
   const [opponentLogo, setOpponentLogo] = useState(null)
+  const [isMobile, setIsMobile] = useState(false)
 
   const isOpaque = (player1Scores, player2Scores) => {
     return player1Scores.map((score, index) => {
@@ -37,6 +38,19 @@ const DashboardTile = ({
   const player2Wins = player1Opacity.length - player1Wins // Total length - player1Wins
   const player1IsWinner = player1Wins > player2Wins
   const player2IsWinner = player2Wins > player1Wins
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 768)
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  const formatName = (name) => {
+    if (!name) return ''
+    const [first, last] = name.split(' ')
+    return isMobile && last ? `${first} ${last[0]}.` : name
+  }
 
   useEffect(() => {
     setClientLogo(logos[clientTeam])
@@ -125,7 +139,7 @@ const DashboardTile = ({
             )}
           </div>
           <div className={styles.playerInfoName}>
-            {renderNameOpacity(player1Name, player1IsWinner)}{' '}
+            {renderNameOpacity(formatName(player1Name), player1IsWinner)}{' '}
             {isUnfinished && '(UF)'}
           </div>
           <div className={styles.playerInfoScore}>
@@ -150,7 +164,7 @@ const DashboardTile = ({
             )}
           </div>
           <div className={styles.playerInfoName}>
-            {renderNameOpacity(player2Name, player2IsWinner)}
+            {renderNameOpacity(formatName(player2Name), player2IsWinner)}
           </div>
           <div className={styles.playerInfoScore}>
             {player2FinalScores.map((score, index) =>

--- a/app/styles/Dashboard.module.css
+++ b/app/styles/Dashboard.module.css
@@ -301,6 +301,13 @@
 }
 
 @media (max-width: 768px) {
+  .headerContent h2 {
+    font-size: 10vw;
+  }
+  .container {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
   .mainContent {
     flex-direction: column;
   }
@@ -314,9 +321,6 @@
     padding-left: 0;
     top: 0;
   }
-}
-
-@media (max-width: 768px) {
   .matchTileContainer {
     grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
   }

--- a/app/styles/Dashboard.module.css
+++ b/app/styles/Dashboard.module.css
@@ -299,3 +299,25 @@
 .buttonBox button:hover {
   background-color: #0056b3;
 }
+
+@media (max-width: 768px) {
+  .mainContent {
+    flex-direction: column;
+  }
+
+  .matchesSection {
+    width: 100%;
+  }
+
+  .rosterContainer {
+    width: 100%;
+    padding-left: 0;
+    top: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .matchTileContainer {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+}

--- a/app/styles/DashboardTile.module.css
+++ b/app/styles/DashboardTile.module.css
@@ -1,7 +1,7 @@
 .dashTilesContainer {
   display: flex;
-  width: 85vw;
-  padding-top: 1.5vw;
+  width: auto;
+  padding-top: 1vw;
   box-sizing: border-box;
 }
 
@@ -9,8 +9,7 @@
   border: 0.13vw solid #dedede;
   border-radius: 1vw;
   font-family: 'DM Sans', sans-serif;
-  width: calc(25% - 0.47vw);
-  margin: 0 0.5vw;
+  width: 100%;
   padding: 0.8vw;
   box-sizing: border-box;
   display: flex;

--- a/app/styles/DashboardTile.module.css
+++ b/app/styles/DashboardTile.module.css
@@ -90,3 +90,49 @@
   height: 100%;
   object-fit: contain;
 }
+
+@media (max-width: 768px) {
+  .containerHeader {
+    padding-bottom: 5px;
+    padding-top: 5px;
+    padding-left: 1px;
+  }
+  .matchInfoContainer {
+    border-radius: 10px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    padding-left: 10px;
+  }
+  .containerTitle {
+    font-size: 3.5vw;
+    font-weight: 400;
+  }
+
+  .taggedBadge {
+    font-size: 8px;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .playerInfo {
+    font-size: 1vw;
+  }
+
+  .playerInfoName {
+    font-size: 4vw;
+    padding-left: 6px;
+  }
+
+  .playerInfoScore {
+    font-size: 4vw;
+    letter-spacing: 5px;
+  }
+
+  @media (max-width: 768px) {
+    .playerSchoolImgcontainerhome,
+    .playerSchoolImgcontainer {
+      width: 20px;
+      height: 20px;
+    }
+  }
+}


### PR DESCRIPTION
***note: used Brandon's changes to match tiles in various bugs #274 , bug 4**
Halfway Pr for this - [#287 Mobile page improvement: dashboard ](https://github.com/bruin-tennis-consulting/match-manager/issues/287)

Did the tiling first because was told this was priority.

Remaining considerations(question for the board): How to trim names inside the match tile

- based on length(ex. 9 chars)? or always trim last name directly, or Trim on last name, unless first name exceed set Char limit
     - Aadarsh Tripathi ==> Aadarsh Tr.
     - or
     -Aadarsh Tripathi ==> Aadarsh T.
     - and
     - Gianluca Balotta ==> Gianluca

**Code Changes**
DashboardTile.js: add name formatting and also media size detector to decide when to format
Dashboard.css and DashboardTile.css: Add media queries and adjust the font size/padding to mobile format

Design look:

<img width="379" alt="Screenshot 2025-02-12 at 9 54 53 PM" src="https://github.com/user-attachments/assets/75680f16-f393-4c05-8baf-255fd528f8d0" />
<img width="379" alt="Screenshot 2025-02-12 at 9 55 04 PM" src="https://github.com/user-attachments/assets/660af698-c9e5-44f4-8e68-c0739b937db9" />
