### PR TITLE
295 creating minimal simple tagger

### DIFF
--- a/app/components/MatchTiles.js
+++ b/app/components/MatchTiles.js
@@ -34,11 +34,9 @@ const MatchTiles = ({
   const [clientLogo, setClientLogo] = useState('')
   const [opponentLogo, setOpponentLogo] = useState('')
 
-
-    // Remove (M) and (W) from team names
-  const changedClientTeam = clientTeam.replace(/\s*\(M\)|\s*\(W\)/g, '') 
-  const changedOpponentTeam = opponentTeam.replace(/\s*\(M\)|\s*\(W\)/g, '') 
-
+  // Remove (M) and (W) from team names
+  const changedClientTeam = clientTeam.replace(/\s*\(M\)|\s*\(W\)/g, '')
+  const changedOpponentTeam = opponentTeam.replace(/\s*\(M\)|\s*\(W\)/g, '')
 
   // to calculate the opcaity
   const player1Opacity = isOpaque(player1FinalScores, player2FinalScores)

--- a/app/components/PlayerProfile.js
+++ b/app/components/PlayerProfile.js
@@ -44,7 +44,7 @@ export default function PlayerProfile({ playerData, playerId }) {
             cols={4}
           />
         ) : (
-          <p>No matches found</p>
+          <p>Loading ... or No matches found</p>
         )}
       </div>
     </div>

--- a/app/match-list/page.js
+++ b/app/match-list/page.js
@@ -76,9 +76,12 @@ export default function MatchList() {
                   <Link href={`/timestamp-tagger?videoId=${match.videoId}`}>
                     <button>Tag Match - Timestamp</button>
                   </Link>
-                  <Link href={`/simple-tagger?videoId=${match.videoId}`}>
+                  <Link
+                    href={`/simple-tagger?videoId=${match.videoId}&matchId=${match.id}`}
+                  >
                     <button>Tag Match - Simple</button>
                   </Link>
+
                   {/* <br />
                   <input onChange={(e) => setNewName(e.target.value)} />
                   <button onClick={() => handleRename(match.id)}>Rename</button> */}

--- a/app/match-list/page.js
+++ b/app/match-list/page.js
@@ -76,6 +76,9 @@ export default function MatchList() {
                   <Link href={`/timestamp-tagger?videoId=${match.videoId}`}>
                     <button>Tag Match - Timestamp</button>
                   </Link>
+                  <Link href={`/simple-tagger?videoId=${match.videoId}`}>
+                    <button>Tag Match - Simple</button>
+                  </Link>
                   {/* <br />
                   <input onChange={(e) => setNewName(e.target.value)} />
                   <button onClick={() => handleRename(match.id)}>Rename</button> */}

--- a/app/profile/[playerId]/page.js
+++ b/app/profile/[playerId]/page.js
@@ -10,7 +10,9 @@ async function getPlayerData(playerId) {
     const cleanString = (str) => str.toLowerCase().replace(/\s+/g, '')
     const querySnapshot = await getDocs(collection(db, 'teams'))
     const teamsData = querySnapshot.docs.map((doc) => doc.data())
-    const mensTeam = teamsData.find((team) => team.name === 'UCLA (M)')
+    const mensTeam = teamsData.find(
+      (team) => team.name === 'University of California, Los Angeles (M)'
+    )
     const [firstName, lastName] = playerId.split('-')
     const targetPlayer = mensTeam?.players?.find(
       (player) =>

--- a/app/services/matchSchemas.js
+++ b/app/services/matchSchemas.js
@@ -1,4 +1,4 @@
-//import { initialSchema, uiSchema as baseUiSchema } from '@/app/services/matchSchemas.js'
+// import { initialSchema, uiSchema as baseUiSchema } from '@/app/services/matchSchemas.js'
 
 const initialSchema = {
   title: 'Upload Match',
@@ -187,7 +187,7 @@ const uiSchema = {
   },
 
   event: {
-    'ui:disabled': (formData) => !formData.duel  // the "event" field is disabled when "dual" is not selected
+    'ui:disabled': (formData) => !formData.duel // the "event" field is disabled when "dual" is not selected
   },
 
   matchScore: {

--- a/app/services/taggerButtonData.js
+++ b/app/services/taggerButtonData.js
@@ -1543,3 +1543,252 @@ export const columnNames = [
   'Surface',
   'Notes'
 ]
+
+export const simpleColumnNames = [
+  'pointScore',
+  'serverName',
+  'firstServeIn',
+  'firstServeZone',
+  'secondServeIn',
+  'secondServeZone',
+  'isWinner'
+]
+
+export const getSimpleTaggerButtonData = (
+  updateActiveRow,
+  addNewRow,
+  setCurrentPage
+) => ({
+  PointScore: [
+    {
+      label: '0-0',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '0-0')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '0-15',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '0-15')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '15-0',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '15-0')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '15-15',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '15-15')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '30-0',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '30-0')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '0-30',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '0-30')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '30-15',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '30-15')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '15-30',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '15-30')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '0-40',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '0-40')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '40-0',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '40-0')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '30-30',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '30-30')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '15-40',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '15-40')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '40-15',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '40-15')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '30-40',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '30-40')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '40-30',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '40-30')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '40-40 (Deuce Side)',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '40-40 (Deuce Side)')
+        setCurrentPage('FirstServeResult')
+      }
+    },
+    {
+      label: '40-40 (Ad Side)',
+      action: (data) => {
+        addNewRow()
+        updateActiveRow('pointScore', '40-40 (Ad Side)')
+        setCurrentPage('FirstServeResult')
+      }
+    }
+  ],
+  FirstServeResult: [
+    {
+      label: 'In',
+      action: (data) => {
+        updateActiveRow('firstServeIn', '1')
+        setCurrentPage('FirstServeZone')
+      }
+    },
+    {
+      label: 'Out',
+      action: (data) => {
+        updateActiveRow('firstServeIn', '0')
+        setCurrentPage('SecondServeResult')
+      }
+    }
+  ],
+  FirstServeZone: [
+    {
+      label: 'Body',
+      action: (data) => {
+        updateActiveRow('firstServeZone', 'Body')
+        setCurrentPage('PointWinner')
+      }
+    },
+    {
+      label: 'Wide',
+      action: (data) => {
+        updateActiveRow('firstServeZone', 'Wide')
+        setCurrentPage('PointWinner')
+      }
+    },
+    {
+      label: 'T',
+      action: (data) => {
+        updateActiveRow('firstServeZone', 'T')
+        setCurrentPage('PointWinner')
+      }
+    }
+  ],
+  SecondServeResult: [
+    {
+      label: 'In',
+      action: (data) => {
+        updateActiveRow('secondServeIn', '1')
+        setCurrentPage('SecondServeZone')
+      }
+    },
+    {
+      label: 'Out',
+      action: (data) => {
+        updateActiveRow('secondServeIn', '0')
+        setCurrentPage('PointWinner')
+      }
+    }
+  ],
+  SecondServeZone: [
+    {
+      label: 'Body',
+      action: (data) => {
+        updateActiveRow('secondServeZone', 'Body')
+        setCurrentPage('PointWinner')
+      }
+    },
+    {
+      label: 'Wide',
+      action: (data) => {
+        updateActiveRow('secondServeZone', 'Wide')
+        setCurrentPage('PointWinner')
+      }
+    },
+    {
+      label: 'T',
+      action: (data) => {
+        updateActiveRow('secondServeZone', 'T')
+        setCurrentPage('PointWinner')
+      }
+    }
+  ],
+  PointWinner: [
+    {
+      label: 'Player 1 Wins',
+      action: (data) => {
+        updateActiveRow('isWinner', 'Player1')
+        setCurrentPage('PointScore')
+      }
+    },
+    {
+      label: 'Player 2 Wins',
+      action: (data) => {
+        updateActiveRow('isWinner', 'Player2')
+        setCurrentPage('PointScore')
+      }
+    }
+  ]
+})

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -27,8 +27,6 @@ async function uploadTeam(teamName, logoFile) {
       logoUrl = await getDownloadURL(snapshot.ref)
     }
 
-   
-
     // Then, save the match data along with the Logo URL to Firestore
     const mens = teamName + ' (M)'
     const womens = teamName + '(W)'

--- a/app/simple-tagger/page.js
+++ b/app/simple-tagger/page.js
@@ -18,7 +18,6 @@ import styles from '@/app/styles/TagMatch.module.css'
 export default function TagMatch() {
   const searchParams = useSearchParams()
   const matchId = searchParams.get('matchId')
-  console.log('Match ID:', matchId)
 
   const { matches, updateMatch, refresh } = useData()
   const match = matches.find((m) => m.id === matchId)

--- a/app/simple-tagger/page.js
+++ b/app/simple-tagger/page.js
@@ -232,35 +232,41 @@ export default function TagMatch() {
       const lastRow = oldTableState.rows[oldTableState.rows.length - 1] || {}
 
       const newRow = columnNames.reduce((acc, columnName) => {
-        if (Object.prototype.hasOwnProperty.call(lastRow, columnName)) {
-          acc[columnName] = lastRow[columnName] // Inherit from previous row
+        if (columnName === 'serverName') {
+          // Always use the latest serverName from state
+          acc[columnName] = serverName
         } else if (columnName === 'pointStartTime') {
           acc[columnName] = newTimestamp
         } else if (columnName === 'isPointStart') {
           acc[columnName] = 1
         } else if (columnName === 'shotInRally') {
           acc[columnName] = 1
+        } else if (Object.prototype.hasOwnProperty.call(lastRow, columnName)) {
+          // Inherit all other properties from the previous row
+          acc[columnName] = lastRow[columnName]
         } else {
-          acc[columnName] = '' // Default empty
+          acc[columnName] = '' // Default empty for new data
         }
         return acc
       }, {})
 
+      // Add the new row to the table
       const updatedTable = [...oldTableState.rows, newRow]
+
+      // Sort rows by pointStartTime to maintain order
       updatedTable.sort((a, b) => a.pointStartTime - b.pointStartTime)
 
-      const newIndex = updatedTable.findIndex(
-        (row) => row.pointStartTime === newTimestamp
-      )
+      // Set activeRowIndex to the most recently added row
+      const newIndex = updatedTable.length - 1 // Directly set to the last row
 
-      // Reset activeRowIndex to the new row
+      // Validate and update errors
       const validationErrors = validateTable(updatedTable, {
         ...matchMetadata,
         activeRowIndex: newIndex
       })
       setErrors(validationErrors)
 
-      return { rows: updatedTable, activeRowIndex: newIndex } // Set activeRowIndex to the newly added row
+      return { rows: updatedTable, activeRowIndex: newIndex } // Set active row correctly
     })
   }
 
@@ -449,6 +455,15 @@ export default function TagMatch() {
       serverName
     }
   )
+
+  // const buttonData = getSimpleTaggerButtonData(
+  //   updateActiveRow,
+  //   () => addNewRowAndSync(serverName), // Pass the latest serverName directly
+  //   setCurrentPage,
+  //   {
+  //     serverName
+  //   }
+  // )
 
   function getErrors(rowIndex, columnName) {
     const cellErrors = errors.filter((error) =>

--- a/app/simple-tagger/page.js
+++ b/app/simple-tagger/page.js
@@ -6,7 +6,8 @@ import { usePathname, useSearchParams } from 'next/navigation'
 import { useData } from '@/app/DataProvider'
 import {
   getSimpleTaggerButtonData,
-  simpleColumnNames
+  simpleColumnNames,
+  columnNames
 } from '@/app/services/taggerButtonData.js' // change this since our columnNames are not the same
 
 import VideoPlayer from '@/app/components/VideoPlayer'
@@ -184,25 +185,67 @@ export default function TagMatch() {
     })
   }
 
+  // const addNewRowAndSync = () => {
+  //   setTableState((oldTableState) => {
+  //     pullAndPushRows(oldTableState.rows, null)
+
+  //     let newTimestamp = getVideoTimestamp()
+
+  //     const newRow = simpleColumnNames.reduce((acc, columnName) => {
+  //       let existingRow = tableState.rows.find(
+  //         (row) => row.pointStartTime === newTimestamp
+  //       )
+
+  //       while (existingRow !== undefined) {
+  //         newTimestamp += 1
+  //         existingRow = tableState.rows.find(
+  //           (row) => row.pointStartTime === newTimestamp
+  //         )
+  //       }
+
+  //       acc[columnName] = columnName === 'pointStartTime' ? newTimestamp : ''
+  //       return acc
+  //     }, {})
+
+  //     const updatedTable = [...oldTableState.rows, newRow]
+  //     updatedTable.sort((a, b) => a.pointStartTime - b.pointStartTime)
+
+  //     const newIndex = updatedTable.findIndex(
+  //       (row) => row.pointStartTime === newTimestamp
+  //     )
+
+  //     setErrors(
+  //       validateTable(updatedTable, {
+  //         ...matchMetadata,
+  //         activeRowIndex: newIndex
+  //       })
+  //     )
+
+  //     return { rows: updatedTable, activeRowIndex: newIndex }
+  //   })
+  // }
+
   const addNewRowAndSync = () => {
     setTableState((oldTableState) => {
-      pullAndPushRows(oldTableState.rows, null)
+      const newTimestamp = getVideoTimestamp()
 
-      let newTimestamp = getVideoTimestamp()
-
-      const newRow = simpleColumnNames.reduce((acc, columnName) => {
-        let existingRow = tableState.rows.find(
-          (row) => row.pointStartTime === newTimestamp
-        )
-
-        while (existingRow !== undefined) {
-          newTimestamp += 1
-          existingRow = tableState.rows.find(
-            (row) => row.pointStartTime === newTimestamp
-          )
+      const newRow = columnNames.reduce((acc, columnName) => {
+        switch (columnName) {
+          case 'pointStartTime':
+            acc[columnName] = newTimestamp
+            break
+          case 'isPointStart':
+            acc[columnName] = 1 // Mark as point start
+            break
+          case 'shotInRally':
+            acc[columnName] = 1 // First shot in the rally
+            break
+          case 'serverName':
+            acc[columnName] = serverName // Set server
+            break
+          default:
+            acc[columnName] = '' // Default empty for unused fields
         }
-
-        acc[columnName] = columnName === 'pointStartTime' ? newTimestamp : ''
         return acc
       }, {})
 
@@ -213,12 +256,12 @@ export default function TagMatch() {
         (row) => row.pointStartTime === newTimestamp
       )
 
-      setErrors(
-        validateTable(updatedTable, {
-          ...matchMetadata,
-          activeRowIndex: newIndex
-        })
-      )
+      // Validate the table to ensure no errors
+      const validationErrors = validateTable(updatedTable, {
+        ...matchMetadata,
+        activeRowIndex: newIndex
+      })
+      setErrors(validationErrors)
 
       return { rows: updatedTable, activeRowIndex: newIndex }
     })

--- a/app/simple-tagger/page.js
+++ b/app/simple-tagger/page.js
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 
 import { useData } from '@/app/DataProvider'
 import {
@@ -16,11 +16,12 @@ import { validateTable } from '@/app/services/taggingValidator'
 import styles from '@/app/styles/TagMatch.module.css'
 
 export default function TagMatch() {
-  const pathname = usePathname()
-  const matchId = pathname.substring(pathname.lastIndexOf('/') + 1)
+  const searchParams = useSearchParams()
+  const matchId = searchParams.get('matchId')
+  console.log('Match ID:', matchId)
+
   const { matches, updateMatch, refresh } = useData()
   const match = matches.find((m) => m.id === matchId)
-  const searchParams = useSearchParams()
 
   const [videoObject, setVideoObject] = useState(null)
   const [videoId, setVideoId] = useState('')
@@ -229,39 +230,34 @@ export default function TagMatch() {
     setTableState((oldTableState) => {
       const newTimestamp = getVideoTimestamp()
 
-      // Create a new row from scratch without inheriting anything
       const newRow = columnNames.reduce((acc, columnName) => {
         if (columnName === 'serverName') {
-          acc[columnName] = serverName // Use the latest server name from state
+          acc[columnName] = serverName
         } else if (columnName === 'pointStartTime') {
-          acc[columnName] = newTimestamp // Set timestamp when point starts
+          acc[columnName] = newTimestamp // don't care abt timestamp for this simple tagger
         } else if (columnName === 'isPointStart') {
-          acc[columnName] = 1 // Mark as the start of a point
+          acc[columnName] = 1 // don't care abt start of a point
         } else if (columnName === 'shotInRally') {
-          acc[columnName] = 1 // Initialize rally shot count
+          acc[columnName] = 1 // don't care abt rally shot count
         } else {
-          acc[columnName] = '' // Default to empty for all other fields
+          acc[columnName] = '' // default to empty for all other fields
         }
         return acc
       }, {})
 
-      // Add the new row to the table
       const updatedTable = [...oldTableState.rows, newRow]
 
-      // Sort rows by pointStartTime to maintain order
       updatedTable.sort((a, b) => a.pointStartTime - b.pointStartTime)
 
-      // Set activeRowIndex to the most recently added row
       const newIndex = updatedTable.length - 1
 
-      // Validate and update errors
       const validationErrors = validateTable(updatedTable, {
         ...matchMetadata,
         activeRowIndex: newIndex
       })
       setErrors(validationErrors)
 
-      return { rows: updatedTable, activeRowIndex: newIndex } // Set active row correctly
+      return { rows: updatedTable, activeRowIndex: newIndex }
     })
   }
 

--- a/app/simple-tagger/page.js
+++ b/app/simple-tagger/page.js
@@ -229,22 +229,19 @@ export default function TagMatch() {
     setTableState((oldTableState) => {
       const newTimestamp = getVideoTimestamp()
 
+      const lastRow = oldTableState.rows[oldTableState.rows.length - 1] || {}
+
       const newRow = columnNames.reduce((acc, columnName) => {
-        switch (columnName) {
-          case 'pointStartTime':
-            acc[columnName] = newTimestamp
-            break
-          case 'isPointStart':
-            acc[columnName] = 1 // Mark as point start
-            break
-          case 'shotInRally':
-            acc[columnName] = 1 // First shot in the rally
-            break
-          case 'serverName':
-            acc[columnName] = serverName // Set server
-            break
-          default:
-            acc[columnName] = '' // Default empty for unused fields
+        if (Object.prototype.hasOwnProperty.call(lastRow, columnName)) {
+          acc[columnName] = lastRow[columnName] // Inherit from previous row
+        } else if (columnName === 'pointStartTime') {
+          acc[columnName] = newTimestamp
+        } else if (columnName === 'isPointStart') {
+          acc[columnName] = 1
+        } else if (columnName === 'shotInRally') {
+          acc[columnName] = 1
+        } else {
+          acc[columnName] = '' // Default empty
         }
         return acc
       }, {})
@@ -256,14 +253,14 @@ export default function TagMatch() {
         (row) => row.pointStartTime === newTimestamp
       )
 
-      // Validate the table to ensure no errors
+      // Reset activeRowIndex to the new row
       const validationErrors = validateTable(updatedTable, {
         ...matchMetadata,
         activeRowIndex: newIndex
       })
       setErrors(validationErrors)
 
-      return { rows: updatedTable, activeRowIndex: newIndex }
+      return { rows: updatedTable, activeRowIndex: newIndex } // Set activeRowIndex to the newly added row
     })
   }
 

--- a/app/simple-tagger/page.js
+++ b/app/simple-tagger/page.js
@@ -1,0 +1,653 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+
+import { useData } from '@/app/DataProvider'
+import {
+  getSimpleTaggerButtonData,
+  simpleColumnNames
+} from '@/app/services/taggerButtonData.js' // change this since our columnNames are not the same
+
+import VideoPlayer from '@/app/components/VideoPlayer'
+import { validateTable } from '@/app/services/taggingValidator'
+
+import styles from '@/app/styles/TagMatch.module.css'
+
+export default function TagMatch() {
+  const pathname = usePathname()
+  const matchId = pathname.substring(pathname.lastIndexOf('/') + 1)
+  const { matches, updateMatch, refresh } = useData()
+  const match = matches.find((m) => m.id === matchId)
+  const searchParams = useSearchParams()
+
+  const [videoObject, setVideoObject] = useState(null)
+  const [videoId, setVideoId] = useState('')
+  const [tableState, setTableState] = useState({
+    rows: [],
+    activeRowIndex: null
+  })
+  const [currentPage, setCurrentPage] = useState('PointScore')
+  const [taggerHistory, setTaggerHistory] = useState([])
+  const [isPublished, setIsPublished] = useState(false)
+  const [matchMetadata, setMatchMetadata] = useState({})
+  const [serverName, setServerName] = useState('Player1')
+  const [initialLoad, setInitialLoad] = useState(true)
+  const [errors, setErrors] = useState([])
+
+  const [popUp, setPopUp] = useState([])
+  const [isVisible, setIsVisible] = useState(true)
+  const FRAMERATE = 30
+
+  // States for Jump To functionality
+  const [jumpMs, setJumpMs] = useState('')
+  const [jumpMinutes, setJumpMinutes] = useState(0)
+  const [jumpSecs, setJumpSecs] = useState(0)
+
+  useEffect(() => {
+    if (match && initialLoad) {
+      console.log('Match object:', match) // Check if match is found
+      console.log('Extracted video ID:', match.videoId) // Check if videoId exists
+      setVideoId(match.videoId)
+      setIsPublished(match.published || false)
+      setTableState((oldTableState) => ({
+        ...oldTableState,
+        rows: match.points || []
+      }))
+
+      const { points, ...metadata } = match
+      setMatchMetadata(metadata)
+      setInitialLoad(false)
+    }
+  }, [match, initialLoad])
+
+  useEffect(() => {
+    const initialVideoId = searchParams.get('videoId') || ''
+    setVideoId(initialVideoId)
+  }, [searchParams])
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [videoObject, videoId, tableState.rows, currentPage])
+
+  useEffect(() => {
+    sortTable()
+  }, [tableState.rows])
+
+  const handleKeyDown = (event) => {
+    if (!videoObject) return
+
+    const keyActions = {
+      ' ': () => {
+        const playing = videoObject.getPlayerState() === 1
+        playing ? videoObject.pauseVideo() : videoObject.playVideo()
+      },
+      d: () => {
+        const newTimestamp = getVideoTimestamp()
+
+        if (
+          tableState.activeRowIndex !== null &&
+          tableState.rows[tableState.activeRowIndex].pointStartTime !== '' &&
+          tableState.rows[tableState.activeRowIndex].pointEndTime === ''
+        ) {
+          saveToHistory()
+          changeRowValue(
+            tableState.activeRowIndex,
+            'pointStartTime',
+            newTimestamp
+          )
+        } else {
+          saveToHistory()
+          addNewRowAndSync()
+        }
+        sortTable()
+      },
+      f: () => {
+        const newTimestamp = getVideoTimestamp()
+        if (tableState.activeRowIndex !== null) {
+          saveToHistory()
+          changeRowValue(
+            tableState.activeRowIndex,
+            'pointEndTime',
+            newTimestamp
+          )
+        }
+      },
+      r: () =>
+        videoObject.seekTo(videoObject.getCurrentTime() + 1 / FRAMERATE, true),
+      e: () =>
+        videoObject.seekTo(videoObject.getCurrentTime() - 1 / FRAMERATE, true),
+      w: () => videoObject.seekTo(videoObject.getCurrentTime() + 5, true),
+      q: () => videoObject.seekTo(videoObject.getCurrentTime() - 5, true),
+      s: () => videoObject.seekTo(videoObject.getCurrentTime() + 10, true),
+      a: () => videoObject.seekTo(videoObject.getCurrentTime() - 10, true),
+      2: () => videoObject.setPlaybackRate(2),
+      1: () => videoObject.setPlaybackRate(1)
+    }
+
+    const action = keyActions[event.key]
+    if (action) action()
+  }
+
+  const changeRowValue = (rowIndex, key, value) => {
+    setTableState((oldTableState) => {
+      const newRows = [...oldTableState.rows]
+      newRows[rowIndex] = { ...newRows[rowIndex], [key]: value }
+      return { ...oldTableState, rows: newRows }
+    })
+  }
+
+  const getVideoTimestamp = () => {
+    return Math.round(videoObject.getCurrentTime() * 1000)
+  }
+
+  const convertToCSV = (data) => {
+    const headers = Object.keys(data[0])
+    const rows = data.map((obj) =>
+      headers.map((fieldName) => JSON.stringify(obj[fieldName])).join(',')
+    )
+    return [headers.join(','), ...rows].join('\n')
+  }
+
+  const handleCopy = () => {
+    const csvData = convertToCSV(tableState.rows)
+    navigator.clipboard.writeText(csvData)
+  }
+
+  const handleDownload = () => {
+    const csvData = convertToCSV(tableState.rows)
+    const blob = new Blob([csvData], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'points.csv'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  const updateActiveRow = (key, value) => {
+    setPopUp((popUp) => [...popUp, `Updating: ${key} = ${value}`])
+    setTableState((oldTableState) => {
+      const newRows = [...oldTableState.rows]
+      if (oldTableState.activeRowIndex !== null) {
+        newRows[oldTableState.activeRowIndex] = {
+          ...newRows[oldTableState.activeRowIndex],
+          [key]: value
+        }
+      }
+      return { ...oldTableState, rows: newRows }
+    })
+  }
+
+  const addNewRowAndSync = () => {
+    setTableState((oldTableState) => {
+      pullAndPushRows(oldTableState.rows, null)
+
+      let newTimestamp = getVideoTimestamp()
+
+      const newRow = simpleColumnNames.reduce((acc, columnName) => {
+        let existingRow = tableState.rows.find(
+          (row) => row.pointStartTime === newTimestamp
+        )
+
+        while (existingRow !== undefined) {
+          newTimestamp += 1
+          existingRow = tableState.rows.find(
+            (row) => row.pointStartTime === newTimestamp
+          )
+        }
+
+        acc[columnName] = columnName === 'pointStartTime' ? newTimestamp : ''
+        return acc
+      }, {})
+
+      const updatedTable = [...oldTableState.rows, newRow]
+      updatedTable.sort((a, b) => a.pointStartTime - b.pointStartTime)
+
+      const newIndex = updatedTable.findIndex(
+        (row) => row.pointStartTime === newTimestamp
+      )
+
+      setErrors(
+        validateTable(updatedTable, {
+          ...matchMetadata,
+          activeRowIndex: newIndex
+        })
+      )
+
+      return { rows: updatedTable, activeRowIndex: newIndex }
+    })
+  }
+
+  const deleteRowAndSync = (rowIndex) => {
+    const rowToDeleteTimestamp = tableState.rows[rowIndex].pointStartTime
+    setTableState((oldTableState) => {
+      const updatedTable = oldTableState.rows.filter(
+        (_, index) => index !== rowIndex
+      )
+      const newActiveRowIndex =
+        rowIndex === oldTableState.activeRowIndex
+          ? oldTableState.activeRowIndex - 1
+          : oldTableState.activeRowIndex
+      setErrors(
+        validateTable(updatedTable, {
+          ...matchMetadata,
+          activeRowIndex: newActiveRowIndex
+        })
+      )
+      return { rows: updatedTable, activeRowIndex: newActiveRowIndex }
+    })
+    pullAndPushRows(tableState.rows, rowToDeleteTimestamp)
+  }
+
+  const saveToHistory = () => {
+    setTaggerHistory((prevHistory) => {
+      const newHistoryEntry = {
+        table: JSON.parse(JSON.stringify(tableState.rows)),
+        page: currentPage,
+        activeRowIndex: tableState.activeRowIndex,
+        popUp
+      }
+      return [...prevHistory, newHistoryEntry].slice(-30)
+    })
+  }
+
+  const getLatestMatchDocument = async (matchId) => {
+    await refresh()
+    const match = matches.find((m) => m.id === matchId)
+
+    if (match) {
+      return match
+    } else {
+      throw new Error(`Match with ID ${matchId} not found.`)
+    }
+  }
+
+  const pullAndPushRows = async (rowState, rowToDeleteTimestamp = null) => {
+    try {
+      const tableSnapshot = [...rowState]
+      const matchDocument = await getLatestMatchDocument(matchId)
+      const incomingRows = matchDocument.points ?? []
+
+      let combinedRows = [...tableSnapshot, ...incomingRows]
+
+      combinedRows =
+        rowToDeleteTimestamp != null
+          ? combinedRows.filter(
+              (row) => row.pointStartTime !== rowToDeleteTimestamp
+            )
+          : combinedRows
+
+      const uniqueRows = combinedRows.reduceRight(
+        (acc, row) => {
+          acc.pointStartTimes.add(row.pointStartTime)
+          if (
+            acc.pointStartTimes.has(row.pointStartTime) &&
+            !acc.added.has(row.pointStartTime)
+          ) {
+            acc.rows.unshift(row)
+            acc.added.add(row.pointStartTime)
+          }
+          return acc
+        },
+        { rows: [], pointStartTimes: new Set(), added: new Set() }
+      ).rows
+
+      uniqueRows.forEach((row) => {
+        for (const key in row) {
+          if (row[key] === undefined) {
+            row[key] = ''
+          }
+        }
+      })
+
+      await updateMatch(matchId, { points: uniqueRows })
+
+      setTableState((oldTableState) => {
+        const currentTableWithOutdatedRemoved = oldTableState.rows.filter(
+          (row) =>
+            !uniqueRows.some(
+              (uniqueRow) => uniqueRow.pointStartTime === row.pointStartTime
+            )
+        )
+
+        const updatedTable = [...currentTableWithOutdatedRemoved, ...uniqueRows]
+
+        updatedTable.sort((a, b) => a.pointStartTime - b.pointStartTime)
+
+        const oldIndex = oldTableState.activeRowIndex
+        const oldActiveRowTimestamp =
+          oldTableState.rows[oldIndex]?.pointStartTime
+        const newIndex = updatedTable.findIndex(
+          (row) => row.pointStartTime === oldActiveRowTimestamp
+        )
+        setErrors(
+          validateTable(updatedTable, {
+            ...matchMetadata,
+            activeRowIndex: newIndex
+          })
+        )
+
+        return { rows: updatedTable, activeRowIndex: newIndex }
+      })
+      sortTable()
+    } catch (error) {
+      console.error('Error pulling and pushing rows: ', error)
+    }
+  }
+
+  const togglePublish = async () => {
+    pullAndPushRows(tableState.rows, null)
+    try {
+      await updateMatch(matchId, { published: !isPublished })
+      setIsPublished(!isPublished)
+    } catch (error) {
+      console.error('Error toggling published state: ', error)
+    }
+  }
+
+  const sortTable = () => {
+    setTableState((oldTableState) => {
+      return {
+        ...oldTableState,
+        rows: oldTableState.rows.sort(
+          (a, b) => a.pointStartTime - b.pointStartTime
+        )
+      }
+    })
+  }
+
+  const undoLastAction = () => {
+    if (taggerHistory.length === 0) return
+
+    const lastState = taggerHistory[taggerHistory.length - 1]
+    setTableState({
+      rows: JSON.parse(JSON.stringify(lastState.table)),
+      activeRowIndex: lastState.activeRowIndex
+    })
+    setCurrentPage(lastState.page)
+    setPopUp(lastState.popUp)
+
+    setErrors(
+      validateTable(lastState.table, {
+        ...matchMetadata,
+        activeRowIndex: lastState.activeRowIndex
+      })
+    )
+
+    setTaggerHistory((prev) => prev.slice(0, -1))
+  }
+
+  // Jump to a specific timestamp in milliseconds
+  const handleJumpToMs = () => {
+    if (videoObject && jumpMs !== '') {
+      const timeInSeconds = parseInt(jumpMs, 10) / 1000
+      videoObject.seekTo(timeInSeconds, true)
+    }
+  }
+
+  // Jump to a specific timestamp given minutes and seconds
+  const handleJumpToMinSec = () => {
+    if (videoObject) {
+      const minutes = parseInt(jumpMinutes, 10) || 0
+      const seconds = parseInt(jumpSecs, 10) || 0
+      const totalSeconds = minutes * 60 + seconds
+      videoObject.seekTo(totalSeconds, true)
+    }
+  }
+
+  const buttonData = getSimpleTaggerButtonData(
+    updateActiveRow,
+    addNewRowAndSync,
+    setCurrentPage,
+    {
+      serverName
+    }
+  )
+
+  function getErrors(rowIndex, columnName) {
+    const cellErrors = errors.filter((error) =>
+      error.cells.some(
+        ([errorRow, errorCol]) =>
+          (errorRow === rowIndex || errorRow === null) &&
+          (errorCol === columnName || errorCol === null)
+      )
+    )
+
+    return cellErrors.length > 0 ? cellErrors : null
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {/* Condensed Jump To Section */}
+      <div style={{ marginBottom: '1rem', marginLeft: '2vw' }}>
+        <h3 style={{ marginBottom: '1vh', marginTop: '0px' }}>
+          {' '}
+          Jump To Timestamp
+        </h3>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '1vw',
+            alignItems: 'flex-end'
+          }}
+        >
+          <div
+            style={{ display: 'flex', flexDirection: 'column', width: '10vw' }}
+          >
+            <label>Milliseconds:</label>
+            <input
+              type="number"
+              value={jumpMs}
+              onChange={(e) => setJumpMs(e.target.value)}
+              placeholder="Enter ms"
+              style={{ width: '10vw' }}
+            />
+          </div>
+          <button
+            onClick={handleJumpToMs}
+            style={{ alignSelf: 'flex-end', height: '4vh', marginRight: '2vw' }}
+          >
+            Jump
+          </button>
+          <div
+            style={{ display: 'flex', flexDirection: 'column', width: '10vw' }}
+          >
+            <label>Minutes:</label>
+            <input
+              type="number"
+              value={jumpMinutes}
+              onChange={(e) => setJumpMinutes(e.target.valueAsNumber || 0)}
+              placeholder="Min"
+              style={{ width: '10vw' }}
+            />
+          </div>
+          <div
+            style={{ display: 'flex', flexDirection: 'column', width: '10vw' }}
+          >
+            <label>Seconds:</label>
+            <input
+              type="number"
+              value={jumpSecs}
+              onChange={(e) => setJumpSecs(e.target.valueAsNumber || 0)}
+              placeholder="Sec"
+              style={{ width: '10vw' }}
+            />
+          </div>
+          <button
+            onClick={handleJumpToMinSec}
+            style={{ alignSelf: 'flex-end', height: '4vh' }}
+          >
+            Jump
+          </button>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          width: '100%',
+          gap: '1rem'
+        }}
+      >
+        {/* Left Column with Left Padding */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '48vw',
+            height: '36vw',
+            paddingLeft: '2vw'
+          }}
+        >
+          <VideoPlayer videoId={videoId} setVideoObject={setVideoObject} />
+          <button onClick={handleDownload}>Download CSV</button>
+          <button onClick={handleCopy}>Copy Columns</button>
+          <button onClick={undoLastAction}>Undo</button>
+          <button onClick={togglePublish}>
+            {isPublished ? 'Unpublish' : 'Publish'}
+          </button>
+          <button onClick={() => setIsVisible(!isVisible)}>
+            {isVisible ? 'Hide Last Command' : 'Show Last Command'}
+          </button>
+        </div>
+
+        <div>
+          <p>{currentPage}</p>
+          <div className={styles.buttonDataControl}>
+            {buttonData[currentPage].map((button, index) => {
+              return button.courtImage ? (
+                <div key={index}>
+                  <p>{button.label}</p>
+                </div>
+              ) : (
+                <button
+                  className={styles.customButton}
+                  key={index}
+                  onClick={() => {
+                    setPopUp([])
+                    saveToHistory()
+                    const data = {
+                      ...matchMetadata,
+                      table: tableState.rows,
+                      activeRowIndex: tableState.activeRowIndex,
+                      videoTimestamp: getVideoTimestamp()
+                    }
+                    button.action(data)
+                  }}
+                >
+                  {button.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div>
+            <p>Current Server: {serverName}</p>
+            <button
+              onClick={() => {
+                setServerName((prevName) =>
+                  prevName === 'Player1' ? 'Player2' : 'Player1'
+                )
+              }}
+            >
+              Toggle Server
+            </button>
+          </div>
+
+          {/* <div>
+            <p>Current Side: {serverFarNear}</p>
+            <button
+              onClick={() => {
+                setServerFarNear((prevSide) =>
+                  prevSide === 'Far' ? 'Near' : 'Far'
+                )
+              }}
+            >
+              Toggle Side
+            </button>
+          </div> */}
+
+          {/* <div>
+            <p>Tiebreak: {tiebreak.toString()}</p>
+            <button
+              onClick={() => {
+                setTiebreak(!tiebreak)
+              }}
+            >
+              Toggle Tiebreak
+            </button>
+          </div> */}
+
+          {isVisible && popUp.length > 0 && (
+            <div className={styles.popUp}>
+              <h2 style={{ fontSize: '20px' }}>Altered Rows:</h2>
+              {popUp.map((message, index) => (
+                <p key={index}>{message}</p>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th key={'delete_button'}>Delete</th>
+            {simpleColumnNames.map((columnName, index) => (
+              <th key={index}>{columnName}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {tableState.rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              <td key={'delete_button_row'}>
+                <button onClick={() => deleteRowAndSync(rowIndex)}>
+                  <i className="fa fa-trash" aria-hidden="true">
+                    X
+                  </i>
+                </button>
+              </td>
+              {simpleColumnNames.map((columnName, colIndex) => {
+                const cellErrors = getErrors(rowIndex, columnName)
+                const errorDescriptions = cellErrors
+                  ? cellErrors.map((error) => error.description).join(', ')
+                  : ''
+                return (
+                  <td key={colIndex}>
+                    <input
+                      type="text"
+                      value={row[columnName] || ''}
+                      onChange={(event) => {
+                        saveToHistory()
+                        changeRowValue(rowIndex, columnName, event.target.value)
+                      }}
+                      style={{
+                        backgroundColor: cellErrors
+                          ? 'lightcoral'
+                          : tableState.activeRowIndex === rowIndex
+                            ? 'yellow'
+                            : 'white'
+                      }}
+                      title={errorDescriptions}
+                    />
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/simple-tagger/page.js
+++ b/app/simple-tagger/page.js
@@ -229,23 +229,18 @@ export default function TagMatch() {
     setTableState((oldTableState) => {
       const newTimestamp = getVideoTimestamp()
 
-      const lastRow = oldTableState.rows[oldTableState.rows.length - 1] || {}
-
+      // Create a new row from scratch without inheriting anything
       const newRow = columnNames.reduce((acc, columnName) => {
         if (columnName === 'serverName') {
-          // Always use the latest serverName from state
-          acc[columnName] = serverName
+          acc[columnName] = serverName // Use the latest server name from state
         } else if (columnName === 'pointStartTime') {
-          acc[columnName] = newTimestamp
+          acc[columnName] = newTimestamp // Set timestamp when point starts
         } else if (columnName === 'isPointStart') {
-          acc[columnName] = 1
+          acc[columnName] = 1 // Mark as the start of a point
         } else if (columnName === 'shotInRally') {
-          acc[columnName] = 1
-        } else if (Object.prototype.hasOwnProperty.call(lastRow, columnName)) {
-          // Inherit all other properties from the previous row
-          acc[columnName] = lastRow[columnName]
+          acc[columnName] = 1 // Initialize rally shot count
         } else {
-          acc[columnName] = '' // Default empty for new data
+          acc[columnName] = '' // Default to empty for all other fields
         }
         return acc
       }, {})
@@ -257,7 +252,7 @@ export default function TagMatch() {
       updatedTable.sort((a, b) => a.pointStartTime - b.pointStartTime)
 
       // Set activeRowIndex to the most recently added row
-      const newIndex = updatedTable.length - 1 // Directly set to the last row
+      const newIndex = updatedTable.length - 1
 
       // Validate and update errors
       const validationErrors = validateTable(updatedTable, {

--- a/app/upload-match/page.js
+++ b/app/upload-match/page.js
@@ -6,7 +6,7 @@ import validator from '@rjsf/validator-ajv8'
 import { dataURItoBlob } from '@rjsf/utils'
 
 import getTeams from '@/app/services/getTeams.js'
-//import { initialSchema, uiSchema } from '@/app/services/matchSchemas.js'
+// import { initialSchema, uiSchema } from '@/app/services/matchSchemas.js'
 import { searchableProperties } from '@/app/services/searchableProperties.js'
 
 import { useData } from '@/app/DataProvider.js'
@@ -14,7 +14,10 @@ import { useAuth } from '@/app/AuthWrapper.js'
 
 import styles from '@/app/styles/Upload.module.css'
 
-import { initialSchema, uiSchema as baseUiSchema } from '@/app/services/matchSchemas.js'
+import {
+  initialSchema,
+  uiSchema as baseUiSchema
+} from '@/app/services/matchSchemas.js'
 
 export default function UploadMatchForm() {
   const { createMatch } = useData() // Use the createMatch hook
@@ -111,7 +114,6 @@ export default function UploadMatchForm() {
         'ui:disabled': !newFormData.duel
       }
     })
-
   }
 
   const validateFileType = (file, expectedType, fieldName) => {
@@ -180,7 +182,6 @@ export default function UploadMatchForm() {
         duel: formData.duel || false
       }
 
-      
       // const sets = parseMatchScore(formData.matchScore);
       const sets = [
         formData.matchScore.set1,
@@ -221,7 +222,7 @@ export default function UploadMatchForm() {
         <Form
           key={JSON.stringify(schema)}
           schema={schema}
-          uiSchema={localUiSchema}  //Changed to use out state variable
+          uiSchema={localUiSchema} // Changed to use out state variable
           formData={formData}
           onChange={handleChange}
           onSubmit={handleSubmit}

--- a/app/upload-team/page.js
+++ b/app/upload-team/page.js
@@ -21,7 +21,7 @@ export default function UploadVideo() {
 
   // prevents re-rendering of teams on other state change (useful when teams is expensive)
   // const memoizedTeams = useMemo(() => teams, [teams]);
-  
+
   useEffect(() => {
     const fetchTeams = async () => {
       try {


### PR DESCRIPTION
#295 

Per Jerry's request, created a **minimal simple tagger as a fallback option for when SwingVision is not working** and we need quick data. 

It includes: 
- point score
- serve in or out
- if in which zone (body wide t) no coordinates
- if out: is second serve in or out (if in, which zone)
- who won point

This will give us the following data which is **easiest data to tag and best reward**
- serve in %
- serve won %
- break point info
- overall points won info
- serve zone info

**Notable Code Edits:**
- simple-tagger: contains logic for the simple tagger
- match-list: added a button to access above simple tagger 
- taggerButtonData: created simpleColumnNames to display for this case and getSimpleTaggerButtonData (similar to getTaggerButtonData)

Since this is the simple version, it only includes data for the fields specified and the rest are either empty by default or whatever it needs for it to be accepting by the backend. (you can see this when you download CSV)

<img width="1100" alt="Screenshot 2025-02-21 at 4 59 25 PM" src="https://github.com/user-attachments/assets/fda79745-c436-43b4-a0d3-789999e63f3e" />

<img width="1102" alt="Screenshot 2025-02-21 at 5 00 03 PM" src="https://github.com/user-attachments/assets/980fb289-f0c2-44c8-9120-8ffd6ac5c802" />


Future direction could be to add more buttons that can be customized such that the entire tagger can be toggleable.