### PR TITLE
295 added gameScore and setScore to simple tagger

### DIFF
--- a/app/services/taggerButtonData.js
+++ b/app/services/taggerButtonData.js
@@ -1546,6 +1546,8 @@ export const columnNames = [
 
 export const simpleColumnNames = [
   'pointScore',
+  'gameScore',
+  'setScore',
   'serverName',
   'firstServeIn',
   'firstServeZone',


### PR DESCRIPTION
Closes additional TODO mentioned in #295 

As per title, added gameScore and setScore to simple tagger. Simple toggles of adding and subtracting for game and set count for each player as well as resetting them to 0-0 for ease.

Additionally edited download CSV so it includes columns only specific to this tagger and not a billion of columns.

<img width="1798" alt="Screenshot 2025-03-01 at 12 39 30 AM" src="https://github.com/user-attachments/assets/56c89914-968f-4fc4-aba3-b7f341223948" />







**Notes:**
- Currently, not sending it this data to Firestore backend as I was unsure if we want to do that. The reason being is that if there previously exists data for the same match (perhaps using full tagger) it could override and remove those...? How should we go about this? If we are sure there is no conflict, we can just uncomment the line to pullAndPushRows.
- An easter egg I noticed is that after downloading to CSV, Excel also converts things like 2-0 to February 0 for some reason. This happens in the full tagger too so I guess if it hasn't hindered any data analysis operations then it is fine as is but wanted to point out!