### PR TITLE
382 feature integrate scouting reports

### DIFF
--- a/app/player-management/page.js
+++ b/app/player-management/page.js
@@ -65,6 +65,7 @@ export default function PlayerManagement() {
   const [editingReport, setEditingReport] = useState(null)
   const [showEditReportModal, setShowEditReportModal] = useState(false)
   const [editReportPdfFile, setEditReportPdfFile] = useState(null)
+  const [showPdfViewer, setShowPdfViewer] = useState(false)
   const [newReport, setNewReport] = useState({
     firstName: '',
     lastName: '',
@@ -1602,9 +1603,38 @@ export default function PlayerManagement() {
               </div>
             )}
 
-            <button className={styles.assignButton}>
+            <button
+              className={styles.assignButton}
+              onClick={() => setShowPdfViewer(true)}
+              disabled={!selectedReport.pdfUrl}
+            >
               View Scouting Report
             </button>
+          </div>
+        )}
+
+        {/* PDF Viewer Overlay */}
+        {showPdfViewer && selectedReport?.pdfUrl && (
+          <div className={styles.pdfOverlay}>
+            <div className={styles.pdfViewerContainer}>
+              <div className={styles.pdfViewerHeader}>
+                <span className={styles.pdfViewerTitle}>
+                  {selectedReport.firstName} {selectedReport.lastName} —{' '}
+                  {selectedReport.date}
+                </span>
+                <button
+                  className={styles.pdfViewerClose}
+                  onClick={() => setShowPdfViewer(false)}
+                >
+                  &times;
+                </button>
+              </div>
+              <iframe
+                src={selectedReport.pdfUrl}
+                className={styles.pdfViewerFrame}
+                title="Scouting Report PDF"
+              />
+            </div>
           </div>
         )}
       </div>

--- a/app/player-management/page.js
+++ b/app/player-management/page.js
@@ -57,6 +57,21 @@ export default function PlayerManagement() {
 
   const classOptions = ['Freshman', 'Sophomore', 'Junior', 'Senior', 'Graduate']
 
+  // state for scouting
+  const [isScoutingMode, setIsScoutingMode] = useState(false)
+  const [scoutingReports, setScoutingReports] = useState([])
+  const [showAddScoutingModal, setShowAddScoutingModal] = useState(false)
+  const [selectedReport, setSelectedReport] = useState(null)
+  const [editingReport, setEditingReport] = useState(null)
+  const [showEditReportModal, setShowEditReportModal] = useState(false)
+  const [editReportPdfFile, setEditReportPdfFile] = useState(null)
+  const [newReport, setNewReport] = useState({
+    firstName: '',
+    lastName: '',
+    date: '',
+    pdfFile: null
+  })
+
   const fetchPlayers = useCallback(async (teamId) => {
     if (!teamId) return // Don't fetch if no team is selected
 
@@ -602,198 +617,273 @@ export default function PlayerManagement() {
         )}
 
         <div className={styles.playersPanel}>
-          <h2>Players</h2>
-          <input
-            type="text"
-            placeholder="Search players..."
-            value={searchQuery}
-            onChange={handleSearch}
-            className={styles.searchInput}
-          />
-          <button
-            className={styles.actionButton}
-            onClick={() => setShowAddPlayerModal(true)}
-            disabled={!selectedTeam}
-          >
-            Add New Player
-          </button>
-
-          {/* Add Player Modal */}
-          {showAddPlayerModal && (
-            <div className={styles.modal}>
-              <div className={styles.modalContent}>
-                <span
-                  className={styles.closeButton}
-                  onClick={() => {
-                    setShowAddPlayerModal(false)
-                    // Reset player form states fully
-                    setNewPlayer({
-                      firstName: '',
-                      lastName: '',
-                      photo: '',
-                      bio: '',
-                      class: 'Freshman',
-                      height: '',
-                      age: '',
-                      hand: 'right',
-                      heightFeet: '',
-                      heightInches: '',
-                      active: true
-                    })
-                    setPlayerHeadPhotoFile(null)
-                    setPlayerLargePhotoFile(null)
-                  }}
+          {isScoutingMode ? (
+            <>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center'
+                }}
+              >
+                <h2>Scouting</h2>
+                <button
+                  className={styles.actionButton}
+                  onClick={() => setIsScoutingMode(false)}
                 >
-                  &times;
-                </span>
-                <h2>
-                  Add New Player to{' '}
-                  {teams.find((t) => t.id === selectedTeam)?.name}
-                </h2>
-                <input
-                  type="text"
-                  placeholder="First Name"
-                  value={newPlayer.firstName}
-                  onChange={(e) =>
-                    setNewPlayer({ ...newPlayer, firstName: e.target.value })
-                  }
-                  className={styles.modalInput}
-                />
-                <input
-                  type="text"
-                  placeholder="Last Name (If middle name or multi-word last name, include here)"
-                  value={newPlayer.lastName}
-                  onChange={(e) =>
-                    setNewPlayer({ ...newPlayer, lastName: e.target.value })
-                  }
-                  className={styles.modalInput}
-                />
-                <input
-                  type="text"
-                  placeholder="Photo URL"
-                  value={newPlayer.photo}
-                  onChange={(e) =>
-                    setNewPlayer({ ...newPlayer, photo: e.target.value })
-                  }
-                  className={styles.modalInput}
-                />
-                <textarea
-                  placeholder="Bio"
-                  value={newPlayer.bio}
-                  onChange={(e) =>
-                    setNewPlayer({ ...newPlayer, bio: e.target.value })
-                  }
-                  className={styles.modalTextarea}
-                />
-                <input
-                  type="text"
-                  placeholder="Class (e.g., Freshman, Sophomore)"
-                  value={newPlayer.class}
-                  onChange={(e) =>
-                    setNewPlayer({ ...newPlayer, class: e.target.value })
-                  }
-                  className={styles.modalInput}
-                />
-                <input
-                  type="text"
-                  placeholder="Height (e.g., 6'1&quot;)"
-                  value={newPlayer.height}
-                  onChange={(e) =>
-                    setNewPlayer({ ...newPlayer, height: e.target.value })
-                  }
-                  className={styles.modalInput}
-                />
-                <input
-                  type="number"
-                  placeholder="Age"
-                  value={newPlayer.age}
-                  onChange={(e) =>
-                    setNewPlayer({ ...newPlayer, age: e.target.value })
-                  }
-                  className={styles.modalInput}
-                />
-                {/* Hand Radio Buttons */}
-                <div className={styles.inputGroup}>
-                  <label className={styles.inputLabel}>Hand:</label>
-                  <div className={styles.radioGroup}>
-                    <label>
-                      <input
-                        type="radio"
-                        name="playerHand"
-                        value="right"
-                        checked={newPlayer.hand === 'right'}
-                        onChange={(e) =>
-                          setNewPlayer({ ...newPlayer, hand: e.target.value })
-                        }
-                      />{' '}
-                      Right
+                  Players
+                </button>
+              </div>
+
+              <button
+                className={styles.actionButton}
+                onClick={() => setShowAddScoutingModal(true)}
+                disabled={!selectedTeam}
+              >
+                Add Scouting Report
+              </button>
+
+              {/* Add Scouting Report Modal */}
+              {showAddScoutingModal && (
+                <div className={styles.modal}>
+                  <div className={styles.modalContent}>
+                    <span
+                      className={styles.closeButton}
+                      onClick={() => {
+                        setShowAddScoutingModal(false)
+                        setNewReport({
+                          firstName: '',
+                          lastName: '',
+                          date: '',
+                          pdfFile: null
+                        })
+                      }}
+                    >
+                      &times;
+                    </span>
+                    <h2>Add Scouting Report</h2>
+                    <input
+                      type="text"
+                      placeholder="First Name"
+                      value={newReport.firstName}
+                      onChange={(e) =>
+                        setNewReport({
+                          ...newReport,
+                          firstName: e.target.value
+                        })
+                      }
+                      className={styles.modalInput}
+                    />
+                    <input
+                      type="text"
+                      placeholder="Last Name"
+                      value={newReport.lastName}
+                      onChange={(e) =>
+                        setNewReport({ ...newReport, lastName: e.target.value })
+                      }
+                      s
+                      className={styles.modalInput}
+                    />
+                    <input
+                      type="date"
+                      value={newReport.date}
+                      onChange={(e) =>
+                        setNewReport({ ...newReport, date: e.target.value })
+                      }
+                      className={styles.modalInput}
+                    />
+                    <label
+                      htmlFor="scoutingPdfUpload"
+                      className={styles.fileInputLabel}
+                    >
+                      Scouting Report PDF:
                     </label>
-                    <label>
-                      <input
-                        type="radio"
-                        name="playerHand"
-                        value="left"
-                        checked={newPlayer.hand === 'left'}
-                        onChange={(e) =>
-                          setNewPlayer({ ...newPlayer, hand: e.target.value })
-                        }
-                      />{' '}
-                      Left
-                    </label>
-                    <label>
-                      <input
-                        type="radio"
-                        name="playerHand"
-                        value="ambidextrous"
-                        checked={newPlayer.hand === 'ambidextrous'}
-                        onChange={(e) =>
-                          setNewPlayer({ ...newPlayer, hand: e.target.value })
-                        }
-                      />{' '}
-                      Ambidextrous
-                    </label>
+                    <input
+                      id="scoutingPdfUpload"
+                      type="file"
+                      accept="application/pdf"
+                      onChange={(e) =>
+                        setNewReport({
+                          ...newReport,
+                          pdfFile: e.target.files[0]
+                        })
+                      }
+                      className={styles.modalInput}
+                    />
+                    {newReport.pdfFile && (
+                      <p className={styles.fileNameDisplay}>
+                        Selected: {newReport.pdfFile.name}
+                      </p>
+                    )}
+                    <button
+                      className={styles.modalButton}
+                      disabled={
+                        !newReport.firstName.trim() ||
+                        !newReport.lastName.trim() ||
+                        !newReport.date ||
+                        !newReport.pdfFile
+                      }
+                      onClick={() => {
+                        setScoutingReports([
+                          ...scoutingReports,
+                          { ...newReport }
+                        ])
+                        setShowAddScoutingModal(false)
+                        setNewReport({
+                          firstName: '',
+                          lastName: '',
+                          date: '',
+                          pdfFile: null
+                        })
+                      }}
+                    >
+                      Add Report
+                    </button>
                   </div>
                 </div>
-                <div className={styles.inputGroup}>
-                  <label className={styles.inputLabel}>Active:</label>
-                  <div className={styles.radioGroup}>
-                    <label>
-                      <input
-                        type="radio"
-                        name="playerActive"
-                        value="true"
-                        checked={newPlayer.active === true}
-                        onChange={() =>
-                          setNewPlayer({
-                            ...newPlayer,
-                            active: true
-                          })
-                        }
-                      />{' '}
-                      Active
-                    </label>
-                    <label>
-                      <input
-                        type="radio"
-                        name="playerActive"
-                        value="false"
-                        checked={newPlayer.active === false}
-                        onChange={() =>
-                          setNewPlayer({
-                            ...newPlayer,
-                            active: false
-                          })
-                        }
-                      />{' '}
-                      Inactive
-                    </label>
-                  </div>
+              )}
+              {/* Scouting Reports List */}
+              {scoutingReports.length === 0 ? (
+                <p>No scouting reports for this team.</p>
+              ) : (
+                <div className={styles.playersList}>
+                  {scoutingReports.map((report, index) => (
+                    <div
+                      key={index}
+                      className={`${styles.playerCard} ${selectedReport === report ? styles.selected : ''}`}
+                      onClick={() => setSelectedReport(report)}
+                    >
+                      <div className={styles.playerInfo}>
+                        <h3>
+                          {report.firstName} {report.lastName}
+                        </h3>
+                        <p>{report.date}</p>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-                <div className={styles.inputGroup}>
-                  {' '}
-                  {/* For Age and Class side-by-side */}
-                  <label className={styles.inputLabel}>
-                    Age:
+              )}
+            </>
+          ) : (
+            <>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center'
+                }}
+              >
+                <h2>Players</h2>
+                <button
+                  className={styles.actionButton}
+                  onClick={() => setIsScoutingMode(true)}
+                >
+                  Scouting
+                </button>
+              </div>
+              <input
+                type="text"
+                placeholder="Search players..."
+                value={searchQuery}
+                onChange={handleSearch}
+                className={styles.searchInput}
+              />
+              <button
+                className={styles.actionButton}
+                onClick={() => setShowAddPlayerModal(true)}
+                disabled={!selectedTeam}
+              >
+                Add New Player
+              </button>
+
+              {/* Add Player Modal */}
+              {showAddPlayerModal && (
+                <div className={styles.modal}>
+                  <div className={styles.modalContent}>
+                    <span
+                      className={styles.closeButton}
+                      onClick={() => {
+                        setShowAddPlayerModal(false)
+                        // Reset player form states fully
+                        setNewPlayer({
+                          firstName: '',
+                          lastName: '',
+                          photo: '',
+                          bio: '',
+                          class: 'Freshman',
+                          height: '',
+                          age: '',
+                          hand: 'right',
+                          heightFeet: '',
+                          heightInches: '',
+                          active: true
+                        })
+                        setPlayerHeadPhotoFile(null)
+                        setPlayerLargePhotoFile(null)
+                      }}
+                    >
+                      &times;
+                    </span>
+                    <h2>
+                      Add New Player to{' '}
+                      {teams.find((t) => t.id === selectedTeam)?.name}
+                    </h2>
+                    <input
+                      type="text"
+                      placeholder="First Name"
+                      value={newPlayer.firstName}
+                      onChange={(e) =>
+                        setNewPlayer({
+                          ...newPlayer,
+                          firstName: e.target.value
+                        })
+                      }
+                      className={styles.modalInput}
+                    />
+                    <input
+                      type="text"
+                      placeholder="Last Name (If middle name or multi-word last name, include here)"
+                      value={newPlayer.lastName}
+                      onChange={(e) =>
+                        setNewPlayer({ ...newPlayer, lastName: e.target.value })
+                      }
+                      className={styles.modalInput}
+                    />
+                    <input
+                      type="text"
+                      placeholder="Photo URL"
+                      value={newPlayer.photo}
+                      onChange={(e) =>
+                        setNewPlayer({ ...newPlayer, photo: e.target.value })
+                      }
+                      className={styles.modalInput}
+                    />
+                    <textarea
+                      placeholder="Bio"
+                      value={newPlayer.bio}
+                      onChange={(e) =>
+                        setNewPlayer({ ...newPlayer, bio: e.target.value })
+                      }
+                      className={styles.modalTextarea}
+                    />
+                    <input
+                      type="text"
+                      placeholder="Class (e.g., Freshman, Sophomore)"
+                      value={newPlayer.class}
+                      onChange={(e) =>
+                        setNewPlayer({ ...newPlayer, class: e.target.value })
+                      }
+                      className={styles.modalInput}
+                    />
+                    <input
+                      type="text"
+                      placeholder="Height (e.g., 6'1&quot;)"
+                      value={newPlayer.height}
+                      onChange={(e) =>
+                        setNewPlayer({ ...newPlayer, height: e.target.value })
+                      }
+                      className={styles.modalInput}
+                    />
                     <input
                       type="number"
                       placeholder="Age"
@@ -803,147 +893,259 @@ export default function PlayerManagement() {
                       }
                       className={styles.modalInput}
                     />
-                  </label>
-                  <label className={styles.inputLabel}>
-                    Class:
-                    <select
-                      value={newPlayer.class}
-                      onChange={(e) =>
-                        setNewPlayer({ ...newPlayer, class: e.target.value })
-                      }
-                      className={
-                        styles.modalInput
-                      } /* Or a specific select style */
-                    >
-                      {classOptions.map((option) => (
-                        <option key={option} value={option}>
-                          {option}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                </div>
+                    {/* Hand Radio Buttons */}
+                    <div className={styles.inputGroup}>
+                      <label className={styles.inputLabel}>Hand:</label>
+                      <div className={styles.radioGroup}>
+                        <label>
+                          <input
+                            type="radio"
+                            name="playerHand"
+                            value="right"
+                            checked={newPlayer.hand === 'right'}
+                            onChange={(e) =>
+                              setNewPlayer({
+                                ...newPlayer,
+                                hand: e.target.value
+                              })
+                            }
+                          />{' '}
+                          Right
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            name="playerHand"
+                            value="left"
+                            checked={newPlayer.hand === 'left'}
+                            onChange={(e) =>
+                              setNewPlayer({
+                                ...newPlayer,
+                                hand: e.target.value
+                              })
+                            }
+                          />{' '}
+                          Left
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            name="playerHand"
+                            value="ambidextrous"
+                            checked={newPlayer.hand === 'ambidextrous'}
+                            onChange={(e) =>
+                              setNewPlayer({
+                                ...newPlayer,
+                                hand: e.target.value
+                              })
+                            }
+                          />{' '}
+                          Ambidextrous
+                        </label>
+                      </div>
+                    </div>
+                    <div className={styles.inputGroup}>
+                      <label className={styles.inputLabel}>Active:</label>
+                      <div className={styles.radioGroup}>
+                        <label>
+                          <input
+                            type="radio"
+                            name="playerActive"
+                            value="true"
+                            checked={newPlayer.active === true}
+                            onChange={() =>
+                              setNewPlayer({
+                                ...newPlayer,
+                                active: true
+                              })
+                            }
+                          />{' '}
+                          Active
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            name="playerActive"
+                            value="false"
+                            checked={newPlayer.active === false}
+                            onChange={() =>
+                              setNewPlayer({
+                                ...newPlayer,
+                                active: false
+                              })
+                            }
+                          />{' '}
+                          Inactive
+                        </label>
+                      </div>
+                    </div>
+                    <div className={styles.inputGroup}>
+                      {' '}
+                      {/* For Age and Class side-by-side */}
+                      <label className={styles.inputLabel}>
+                        Age:
+                        <input
+                          type="number"
+                          placeholder="Age"
+                          value={newPlayer.age}
+                          onChange={(e) =>
+                            setNewPlayer({ ...newPlayer, age: e.target.value })
+                          }
+                          className={styles.modalInput}
+                        />
+                      </label>
+                      <label className={styles.inputLabel}>
+                        Class:
+                        <select
+                          value={newPlayer.class}
+                          onChange={(e) =>
+                            setNewPlayer({
+                              ...newPlayer,
+                              class: e.target.value
+                            })
+                          }
+                          className={
+                            styles.modalInput
+                          } /* Or a specific select style */
+                        >
+                          {classOptions.map((option) => (
+                            <option key={option} value={option}>
+                              {option}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
 
-                <div className={styles.inputGroup}>
-                  {' '}
-                  {/* For Height Feet and Inches */}
-                  <label className={styles.inputLabel}>Height:</label>
-                  <input
-                    type="number"
-                    placeholder="Feet"
-                    min="0"
-                    value={newPlayer.heightFeet}
-                    onChange={(e) =>
-                      setNewPlayer({ ...newPlayer, heightFeet: e.target.value })
-                    }
-                    className={styles.modalInputSmall}
-                  />
-                  <span>&apos;&nbsp;</span>
-                  <input
-                    type="number"
-                    placeholder="Inches"
-                    min="0"
-                    max="11"
-                    value={newPlayer.heightInches}
-                    onChange={(e) =>
-                      setNewPlayer({
-                        ...newPlayer,
-                        heightInches: e.target.value
-                      })
-                    }
-                    className={styles.modalInputSmall}
-                  />
-                </div>
-
-                <label
-                  htmlFor="playerHeadPhoto"
-                  className={styles.fileInputLabel}
-                >
-                  Player Head Photo (webp, svg, png, jpg):
-                </label>
-                <input
-                  id="playerHeadPhoto"
-                  type="file"
-                  accept="image/webp,image/svg+xml,image/png,image/jpeg"
-                  onChange={(e) => setPlayerHeadPhotoFile(e.target.files[0])}
-                  className={styles.modalInput}
-                />
-                {playerHeadPhotoFile && (
-                  <p className={styles.fileNameDisplay}>
-                    Selected: {playerHeadPhotoFile.name}
-                  </p>
-                )}
-
-                <label
-                  htmlFor="playerLargePhoto"
-                  className={styles.fileInputLabel}
-                >
-                  Large Player Photo (webp, svg, png, jpg):
-                </label>
-                <input
-                  id="playerLargePhoto"
-                  type="file"
-                  accept="image/webp,image/svg+xml,image/png,image/jpeg"
-                  onChange={(e) => setPlayerLargePhotoFile(e.target.files[0])}
-                  className={styles.modalInput}
-                />
-                {playerLargePhotoFile && (
-                  <p className={styles.fileNameDisplay}>
-                    Selected: {playerLargePhotoFile.name}
-                  </p>
-                )}
-
-                <button
-                  onClick={handleAddPlayer}
-                  className={styles.modalButton}
-                >
-                  Add Player
-                </button>
-              </div>
-            </div>
-          )}
-
-          {loading ? (
-            <p>Loading players...</p>
-          ) : error ? (
-            <p className={styles.error}>{error}</p>
-          ) : filteredPlayers.length === 0 ? (
-            <p>No players found</p>
-          ) : (
-            <div className={styles.playersList}>
-              {filteredPlayers.map((player, index) => (
-                <div
-                  key={index}
-                  className={`${styles.playerCard} ${selectedPlayer === player ? styles.selected : ''}`}
-                  onClick={() => handlePlayerSelect(player)}
-                >
-                  <div className={styles.playerImage}>
-                    {player.photo ? (
-                      <Image
-                        src={player.photo}
-                        alt={`${player.firstName} ${player.lastName}`}
-                        width={100}
-                        height={100}
-                        style={{ objectFit: 'cover' }}
-                        priority={index < 4} // Prioritize loading first 4 images
+                    <div className={styles.inputGroup}>
+                      {' '}
+                      {/* For Height Feet and Inches */}
+                      <label className={styles.inputLabel}>Height:</label>
+                      <input
+                        type="number"
+                        placeholder="Feet"
+                        min="0"
+                        value={newPlayer.heightFeet}
+                        onChange={(e) =>
+                          setNewPlayer({
+                            ...newPlayer,
+                            heightFeet: e.target.value
+                          })
+                        }
+                        className={styles.modalInputSmall}
                       />
-                    ) : (
-                      <div className={styles.noImage}>No Image</div>
+                      <span>&apos;&nbsp;</span>
+                      <input
+                        type="number"
+                        placeholder="Inches"
+                        min="0"
+                        max="11"
+                        value={newPlayer.heightInches}
+                        onChange={(e) =>
+                          setNewPlayer({
+                            ...newPlayer,
+                            heightInches: e.target.value
+                          })
+                        }
+                        className={styles.modalInputSmall}
+                      />
+                    </div>
+
+                    <label
+                      htmlFor="playerHeadPhoto"
+                      className={styles.fileInputLabel}
+                    >
+                      Player Head Photo (webp, svg, png, jpg):
+                    </label>
+                    <input
+                      id="playerHeadPhoto"
+                      type="file"
+                      accept="image/webp,image/svg+xml,image/png,image/jpeg"
+                      onChange={(e) =>
+                        setPlayerHeadPhotoFile(e.target.files[0])
+                      }
+                      className={styles.modalInput}
+                    />
+                    {playerHeadPhotoFile && (
+                      <p className={styles.fileNameDisplay}>
+                        Selected: {playerHeadPhotoFile.name}
+                      </p>
                     )}
-                  </div>
-                  <div className={styles.playerInfo}>
-                    <h3>
-                      {player.firstName} {player.lastName}
-                    </h3>
-                    <p>{player.bio}</p>
+
+                    <label
+                      htmlFor="playerLargePhoto"
+                      className={styles.fileInputLabel}
+                    >
+                      Large Player Photo (webp, svg, png, jpg):
+                    </label>
+                    <input
+                      id="playerLargePhoto"
+                      type="file"
+                      accept="image/webp,image/svg+xml,image/png,image/jpeg"
+                      onChange={(e) =>
+                        setPlayerLargePhotoFile(e.target.files[0])
+                      }
+                      className={styles.modalInput}
+                    />
+                    {playerLargePhotoFile && (
+                      <p className={styles.fileNameDisplay}>
+                        Selected: {playerLargePhotoFile.name}
+                      </p>
+                    )}
+
+                    <button
+                      onClick={handleAddPlayer}
+                      className={styles.modalButton}
+                    >
+                      Add Player
+                    </button>
                   </div>
                 </div>
-              ))}
-            </div>
+              )}
+
+              {loading ? (
+                <p>Loading players...</p>
+              ) : error ? (
+                <p className={styles.error}>{error}</p>
+              ) : filteredPlayers.length === 0 ? (
+                <p>No players found</p>
+              ) : (
+                <div className={styles.playersList}>
+                  {filteredPlayers.map((player, index) => (
+                    <div
+                      key={index}
+                      className={`${styles.playerCard} ${selectedPlayer === player ? styles.selected : ''}`}
+                      onClick={() => handlePlayerSelect(player)}
+                    >
+                      <div className={styles.playerImage}>
+                        {player.photo ? (
+                          <Image
+                            src={player.photo}
+                            alt={`${player.firstName} ${player.lastName}`}
+                            width={100}
+                            height={100}
+                            style={{ objectFit: 'cover' }}
+                            priority={index < 4} // Prioritize loading first 4 images
+                          />
+                        ) : (
+                          <div className={styles.noImage}>No Image</div>
+                        )}
+                      </div>
+                      <div className={styles.playerInfo}>
+                        <h3>
+                          {player.firstName} {player.lastName}
+                        </h3>
+                        <p>{player.bio}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
           )}
         </div>
 
-        {selectedPlayer && (
+        {!isScoutingMode && selectedPlayer && (
           <div className={styles.assignPanel}>
             <h2>Player Details</h2>
             <div className={styles.selectedPlayerCard}>
@@ -1240,6 +1442,107 @@ export default function PlayerManagement() {
                 Assign to Team
               </button>
             </div>
+          </div>
+        )}
+
+        {isScoutingMode && selectedReport && (
+          <div className={styles.assignPanel}>
+            <h2>Report Details</h2>
+            <div className={styles.selectedPlayerCard}>
+              <h3>
+                {selectedReport.firstName} {selectedReport.lastName}
+              </h3>
+              <p>
+                <strong>Date:</strong> {selectedReport.date}
+              </p>
+              <button
+                onClick={() => {
+                  setEditingReport({ ...selectedReport })
+                  setEditReportPdfFile(null)
+                  setShowEditReportModal(true)
+                }}
+                className={styles.editButton}
+              >
+                Edit Report
+              </button>
+            </div>
+
+            {/* Edit Scouting Report Modal */}
+            {showEditReportModal && editingReport && (
+              <div className={styles.modal}>
+                <div className={styles.modalContent}>
+                  <span
+                    className={styles.closeButton}
+                    onClick={() => {
+                      setShowEditReportModal(false)
+                      setEditingReport(null)
+                      setEditReportPdfFile(null)
+                    }}
+                  >
+                    &times;
+                  </span>
+                  <h2>Edit Scouting Report</h2>
+                  <input
+                    type="text"
+                    placeholder="First Name"
+                    value={editingReport.firstName}
+                    onChange={(e) =>
+                      setEditingReport({
+                        ...editingReport,
+                        firstName: e.target.value
+                      })
+                    }
+                    className={styles.modalInput}
+                  />
+                  <input
+                    type="text"
+                    placeholder="Last Name"
+                    value={editingReport.lastName}
+                    onChange={(e) =>
+                      setEditingReport({
+                        ...editingReport,
+                        lastName: e.target.value
+                      })
+                    }
+                    className={styles.modalInput}
+                  />
+                  <input
+                    type="date"
+                    value={editingReport.date}
+                    onChange={(e) =>
+                      setEditingReport({
+                        ...editingReport,
+                        date: e.target.value
+                      })
+                    }
+                    className={styles.modalInput}
+                  />
+                  <label
+                    htmlFor="editReportPdfUpload"
+                    className={styles.fileInputLabel}
+                  >
+                    Replace Scouting Report PDF:
+                  </label>
+                  <input
+                    id="editReportPdfUpload"
+                    type="file"
+                    accept="application/pdf"
+                    onChange={(e) => setEditReportPdfFile(e.target.files[0])}
+                    className={styles.modalInput}
+                  />
+                  {editReportPdfFile && (
+                    <p className={styles.fileNameDisplay}>
+                      Selected: {editReportPdfFile.name}
+                    </p>
+                  )}
+                  <button className={styles.modalButton}>Update Report</button>
+                </div>
+              </div>
+            )}
+
+            <button className={styles.assignButton}>
+              View Scouting Report
+            </button>
           </div>
         )}
       </div>

--- a/app/player-management/page.js
+++ b/app/player-management/page.js
@@ -84,8 +84,10 @@ export default function PlayerManagement() {
       if (!teamSnapshot.empty) {
         const teamData = teamSnapshot.docs[0].data()
         setPlayers(teamData.players || [])
+        setScoutingReports(teamData.scoutingReports || [])
       } else {
         setPlayers([])
+        setScoutingReports([])
       }
     } catch (err) {
       console.error('Error fetching players:', err)
@@ -292,6 +294,77 @@ export default function PlayerManagement() {
       setMessage('') // Or use: setMessage('Failed to create team. Please try again.')
     } finally {
       setIsCreatingTeam(false)
+    }
+  }
+
+  const handleScoutingReportSubmit = async () => {
+    if (!selectedTeam) {
+      setMessage('Please select a team first.')
+      return
+    }
+    if (
+      !newReport.firstName.trim() ||
+      !newReport.lastName.trim() ||
+      !newReport.date ||
+      !newReport.pdfFile
+    ) {
+      setMessage('All fields and a PDF file are required.')
+      return
+    }
+
+    try {
+      setLoading(true)
+      // Upload PDF to Firebase Storage to "scouting-pdfs/teamID/date_pdfileanme"
+      const pdfRef = ref(
+        storage,
+        `scouting-pdfs/${selectedTeam}/${Date.now()}_${newReport.pdfFile.name}`
+      )
+      await uploadBytes(pdfRef, newReport.pdfFile)
+      const pdfUrl = await getDownloadURL(pdfRef)
+
+      // Build the report object
+      const reportToAdd = {
+        firstName: newReport.firstName.trim(),
+        lastName: newReport.lastName.trim(),
+        date: newReport.date,
+        pdfUrl
+      }
+
+      // Update team document with new scouting report
+      const teamRef = doc(db, 'teams', selectedTeam)
+      const teamSnapshot = await getDocs(
+        query(collection(db, 'teams'), where('__name__', '==', selectedTeam))
+      )
+
+      if (teamSnapshot.empty) {
+        setMessage('Selected team not found.')
+        setLoading(false)
+        return
+      }
+
+      const teamData = teamSnapshot.docs[0].data()
+      const updatedReports = [...(teamData.scoutingReports || []), reportToAdd]
+
+      await updateDoc(teamRef, {
+        scoutingReports: updatedReports
+      })
+
+      setMessage(
+        `Scouting report for ${reportToAdd.firstName} ${reportToAdd.lastName} added successfully!`
+      )
+      setNewReport({
+        firstName: '',
+        lastName: '',
+        date: '',
+        pdfFile: null
+      })
+      setShowAddScoutingModal(false)
+      fetchPlayers(selectedTeam) // Refresh data
+    } catch (err) {
+      console.error('Error adding scouting report:', err)
+      setMessage('Failed to add scouting report. ' + err.message)
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -721,23 +794,12 @@ export default function PlayerManagement() {
                         !newReport.firstName.trim() ||
                         !newReport.lastName.trim() ||
                         !newReport.date ||
-                        !newReport.pdfFile
+                        !newReport.pdfFile ||
+                        loading
                       }
-                      onClick={() => {
-                        setScoutingReports([
-                          ...scoutingReports,
-                          { ...newReport }
-                        ])
-                        setShowAddScoutingModal(false)
-                        setNewReport({
-                          firstName: '',
-                          lastName: '',
-                          date: '',
-                          pdfFile: null
-                        })
-                      }}
+                      onClick={handleScoutingReportSubmit}
                     >
-                      Add Report
+                      {loading ? 'Uploading...' : 'Add Report'}
                     </button>
                   </div>
                 </div>

--- a/app/player-management/page.js
+++ b/app/player-management/page.js
@@ -9,7 +9,12 @@ import {
   updateDoc,
   addDoc
 } from 'firebase/firestore'
-import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
+import {
+  ref,
+  uploadBytes,
+  getDownloadURL,
+  deleteObject
+} from 'firebase/storage'
 import { db, storage } from '@/app/services/initializeFirebase.js'
 import styles from '@/app/styles/PlayerManagement.module.css'
 import Image from 'next/image'
@@ -364,6 +369,53 @@ export default function PlayerManagement() {
     } catch (err) {
       console.error('Error adding scouting report:', err)
       setMessage('Failed to add scouting report. ' + err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDeleteScoutingReport = async () => {
+    if (!selectedTeam || !selectedReport) return
+
+    try {
+      setLoading(true)
+
+      // Delete PDF from Firebase Storage
+      if (selectedReport.pdfUrl) {
+        const pdfRef = ref(storage, selectedReport.pdfUrl)
+        await deleteObject(pdfRef)
+      }
+
+      // Remove report from team's scoutingReports array, matching by pdfUrl to handle duplicate names
+      const teamRef = doc(db, 'teams', selectedTeam)
+      const teamSnapshot = await getDocs(
+        query(collection(db, 'teams'), where('__name__', '==', selectedTeam))
+      )
+
+      if (teamSnapshot.empty) {
+        setMessage('Selected team not found.')
+        setLoading(false)
+        return
+      }
+
+      const teamData = teamSnapshot.docs[0].data()
+      const updatedReports = (teamData.scoutingReports || []).filter(
+        (report) => report.pdfUrl !== selectedReport.pdfUrl
+      )
+
+      await updateDoc(teamRef, {
+        scoutingReports: updatedReports
+      })
+
+      setMessage(
+        `Scouting report for ${selectedReport.firstName} ${selectedReport.lastName} deleted successfully!`
+      )
+      setSelectedReport(null)
+      setShowPdfViewer(false)
+      fetchPlayers(selectedTeam)
+    } catch (err) {
+      console.error('Error deleting scouting report:', err)
+      setMessage('Failed to delete scouting report. ' + err.message)
     } finally {
       setLoading(false)
     }
@@ -1609,6 +1661,13 @@ export default function PlayerManagement() {
               disabled={!selectedReport.pdfUrl}
             >
               View Scouting Report
+            </button>
+            <button
+              className={styles.deleteButton}
+              onClick={handleDeleteScoutingReport}
+              disabled={loading}
+            >
+              {loading ? 'Deleting...' : 'Delete Report'}
             </button>
           </div>
         )}

--- a/app/styles/PlayerManagement.module.css
+++ b/app/styles/PlayerManagement.module.css
@@ -397,6 +397,28 @@
   cursor: not-allowed;
 }
 
+.deleteButton {
+  background-color: #e74c3c;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 10px;
+  width: 100%;
+  font-size: 14px;
+  transition: background-color 0.3s ease;
+}
+
+.deleteButton:hover {
+  background-color: #c0392b;
+}
+
+.deleteButton:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
 /* PDF Viewer Overlay */
 .pdfOverlay {
   position: fixed;

--- a/app/styles/PlayerManagement.module.css
+++ b/app/styles/PlayerManagement.module.css
@@ -396,3 +396,67 @@
   background-color: #ccc;
   cursor: not-allowed;
 }
+
+/* PDF Viewer Overlay */
+.pdfOverlay {
+  position: fixed;
+  z-index: 2000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pdfViewerContainer {
+  width: 90%;
+  height: 90%;
+  max-width: 1200px;
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.pdfViewerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #2c3e50;
+  color: white;
+  padding: 10px 16px;
+  flex-shrink: 0;
+}
+
+.pdfViewerTitle {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pdfViewerClose {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.pdfViewerClose:hover {
+  color: #e74c3c;
+}
+
+.pdfViewerFrame {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: white;
+}


### PR DESCRIPTION
**Features Added:**
- Under player-management, add alternate for adding scouting reports
- Add scouting-pdfs to firebase storage and scouting-report fields to team collections
      - for now, details stored about scouting reports are: first name, last name, date(of match), and pdf
- view scouting reports in the player management page

**Changes**
 /player-management/page.js
- Add States for managing scouting report sides
- Add handler for uploading new scouting reports
- In UI portion for displaying Players and player info, add alternative for viewing scouting reports and scouting report info
      -  Code changes are selection of scouting info, and rearranging existing code for uploading/viewing player
/style/player-managment.js
- add styling for pdf viewier

**Todo/considerations**
- might be additional info relevant to each pdf, included what I thought mattered for now
- Next step is just finding schedule for upcoming matches, then in matches page, its easy to add a pdf viewer to look at future scouting reports